### PR TITLE
Allowing token authentication: resolves #11

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,6 +61,9 @@ local_settings.py
 instance/
 .webassets-cache
 
+# Pycharm stuff:
+.idea
+
 # Scrapy stuff:
 .scrapy
 

--- a/.gitignore
+++ b/.gitignore
@@ -61,6 +61,9 @@ local_settings.py
 instance/
 .webassets-cache
 
+# PyCharm stuff
+.idea
+
 # Scrapy stuff:
 .scrapy
 

--- a/.gitignore
+++ b/.gitignore
@@ -61,9 +61,6 @@ local_settings.py
 instance/
 .webassets-cache
 
-# Pycharm stuff:
-.idea
-
 # Scrapy stuff:
 .scrapy
 

--- a/pyCIPAPI/auth.py
+++ b/pyCIPAPI/auth.py
@@ -2,11 +2,8 @@
 
 from __future__ import print_function, absolute_import
 import json
-import jwt
-from jwt.exceptions import ExpiredSignatureError, DecodeError, InvalidTokenError
 import requests
 import maya
-from datetime import datetime
 from .auth_credentials import auth_credentials
 from .config import live_100k_data_base_url, beta_testing_base_url
 
@@ -15,7 +12,7 @@ from .config import live_100k_data_base_url, beta_testing_base_url
 class AuthenticatedCIPAPISession(requests.Session):
     """Subclass of requests Session for authenticating against GEL CIPAPI."""
 
-    def __init__(self, testing_on=False, token=None):
+    def __init__(self, testing_on=False):
         """Init AuthenticatedCIPAPISession and run authenticate function.
 
         Authentication credentials are stored in auth_credentials.py and are in
@@ -25,40 +22,7 @@ class AuthenticatedCIPAPISession(requests.Session):
 
         """
         requests.Session.__init__(self)
-
-        if token:
-            self.update_token(token)
-        else:
-            self.authenticate(testing_on=testing_on)
-
-    def update_token(self, token):
-        """Update session token with a user supplied one.
-
-        Stores the JWT token and updates creation and expiration time from payload.
-
-        Returns:
-            The current instance of AuthenticatedCIPAPISession with the headers
-            set to include token, the auth_time and auth_expires time.
-        """
-
-        try:
-            decoded_token = jwt.decode(token, verify=False)
-            self.headers.update({"Authorization": "JWT " + token})
-            self.auth_time = datetime.fromtimestamp(decoded_token['orig_iat'])
-            self.auth_expires = datetime.fromtimestamp(decoded_token['exp'])
-        except (InvalidTokenError, DecodeError, ExpiredSignatureError, KeyError):
-            self.auth_time = False
-            raise Exception('Invalid or expired JWT token')
-        except:
-            raise
-
-        # Check whether the token has expired
-        if datetime.now() > self.auth_expires:
-            raise Exception('JWT token has expired')
-        else:
-            pass
-
-        return self
+        self.authenticate(testing_on=testing_on)
 
     def authenticate(self, testing_on=False):
         """Use auth_credentials to generate an authenticated session.
@@ -71,7 +35,7 @@ class AuthenticatedCIPAPISession(requests.Session):
             The current instance of AuthenticatedCIPAPISession with the headers
             set to include token, the auth_time and auth_expires time.
         """
-
+        
         # Use the correct url if using beta dataset for testing:
         if testing_on == False:
             # Live data
@@ -84,14 +48,20 @@ class AuthenticatedCIPAPISession(requests.Session):
             token = (self.post(
                         cip_auth_url, data=(auth_credentials))
                      .json()['token'])
-            decoded_token = jwt.decode(token, verify=False)
             self.headers.update({"Authorization": "JWT " + token})
-            self.auth_time = datetime.fromtimestamp(decoded_token['orig_iat'])
-            self.auth_expires = datetime.fromtimestamp(decoded_token['exp'])
+            self.auth_time = maya.now()
+            self.auth_expires = self.auth_time.add(minutes=30)
         except KeyError:
             self.auth_time = False
             print('Authentication Error')
         return self
+
+    def check_auth(self, testing_on=False):
+        """Check whether the session is still authenticated."""
+        if maya.now() > self.auth_expires():
+            self.authenticate(testing_on=testing_on)
+        else:
+            pass
 
 
 class AuthenticatedOpenCGASession(requests.Session):

--- a/pyCIPAPI/auth.py
+++ b/pyCIPAPI/auth.py
@@ -2,8 +2,11 @@
 
 from __future__ import print_function, absolute_import
 import json
+import jwt
+from jwt.exceptions import ExpiredSignatureError, DecodeError, InvalidTokenError
 import requests
 import maya
+from datetime import datetime
 from .auth_credentials import auth_credentials
 from .config import live_100k_data_base_url, beta_testing_base_url
 
@@ -12,7 +15,7 @@ from .config import live_100k_data_base_url, beta_testing_base_url
 class AuthenticatedCIPAPISession(requests.Session):
     """Subclass of requests Session for authenticating against GEL CIPAPI."""
 
-    def __init__(self, testing_on=False):
+    def __init__(self, testing_on=False, token=None):
         """Init AuthenticatedCIPAPISession and run authenticate function.
 
         Authentication credentials are stored in auth_credentials.py and are in
@@ -22,11 +25,43 @@ class AuthenticatedCIPAPISession(requests.Session):
 
         """
         requests.Session.__init__(self)
-        self.authenticate(testing_on=testing_on)
+
+        if token:
+            self.update_token(token)
+        else:
+            self.authenticate(testing_on=testing_on)
+
+    def update_token(self, token):
+        """Update session token with a user supplied one.
+
+        Stores the JWT token and updates creation and expiration time from payload.
+
+        Returns:
+            The current instance of AuthenticatedCIPAPISession with the headers
+            set to include token, the auth_time and auth_expires time.
+        """
+
+        try:
+            decoded_token = jwt.decode(token, verify=False)
+            self.headers.update({"Authorization": "JWT " + token})
+            self.auth_time = datetime.fromtimestamp(decoded_token['orig_iat'])
+            self.auth_expires = datetime.fromtimestamp(decoded_token['exp'])
+        except (InvalidTokenError, DecodeError, ExpiredSignatureError, KeyError):
+            self.auth_time = False
+            raise Exception('Invalid or expired JWT token')
+        except:
+            raise
+
+        # Check whether the token has expired
+        if datetime.now() > self.auth_expires:
+            raise Exception('JWT token has expired')
+        else:
+            pass
+
+        return self
 
     def authenticate(self, testing_on=False):
         """Use auth_credentials to generate an authenticated session.
-
         Uses the cip_auth_url hard coded in and credentials in the
         auth_credentials file to retrieve an authentication token from the CIP
         API.
@@ -35,7 +70,6 @@ class AuthenticatedCIPAPISession(requests.Session):
             The current instance of AuthenticatedCIPAPISession with the headers
             set to include token, the auth_time and auth_expires time.
         """
-        
         # Use the correct url if using beta dataset for testing:
         if testing_on == False:
             # Live data
@@ -43,25 +77,18 @@ class AuthenticatedCIPAPISession(requests.Session):
         else:
             # Beta test data
             cip_auth_url = (beta_testing_base_url + 'get-token/')
-
         try:
             token = (self.post(
                         cip_auth_url, data=(auth_credentials))
                      .json()['token'])
+            decoded_token = jwt.decode(token, verify=False)
             self.headers.update({"Authorization": "JWT " + token})
-            self.auth_time = maya.now()
-            self.auth_expires = self.auth_time.add(minutes=30)
+            self.auth_time = datetime.fromtimestamp(decoded_token['orig_iat'])
+            self.auth_expires = datetime.fromtimestamp(decoded_token['exp'])
         except KeyError:
             self.auth_time = False
             print('Authentication Error')
         return self
-
-    def check_auth(self, testing_on=False):
-        """Check whether the session is still authenticated."""
-        if maya.now() > self.auth_expires():
-            self.authenticate(testing_on=testing_on)
-        else:
-            pass
 
 
 class AuthenticatedOpenCGASession(requests.Session):

--- a/pyCIPAPI/auth.py
+++ b/pyCIPAPI/auth.py
@@ -6,7 +6,7 @@ import jwt
 from jwt.exceptions import ExpiredSignatureError, DecodeError, InvalidTokenError
 import requests
 import maya
-from datetime import datetime
+from datetime import datetime, timedelta
 from .auth_credentials import auth_credentials
 from .config import live_100k_data_base_url, beta_testing_base_url
 
@@ -53,7 +53,7 @@ class AuthenticatedCIPAPISession(requests.Session):
             raise
 
         # Check whether the token has expired
-        if datetime.now() > self.auth_expires:
+        if datetime.now() > self.auth_expires - timedelta(minutes=10):
             raise Exception('JWT token has expired')
         else:
             pass
@@ -90,7 +90,10 @@ class AuthenticatedCIPAPISession(requests.Session):
             self.auth_expires = datetime.fromtimestamp(decoded_token['exp'])
         except KeyError:
             self.auth_time = False
-            print('Authentication Error')
+            raise Exception('Authentication Error')
+        except:
+            raise
+
         return self
 
 

--- a/pyCIPAPI/auth.py
+++ b/pyCIPAPI/auth.py
@@ -62,6 +62,7 @@ class AuthenticatedCIPAPISession(requests.Session):
 
     def authenticate(self, testing_on=False):
         """Use auth_credentials to generate an authenticated session.
+
         Uses the cip_auth_url hard coded in and credentials in the
         auth_credentials file to retrieve an authentication token from the CIP
         API.
@@ -70,6 +71,7 @@ class AuthenticatedCIPAPISession(requests.Session):
             The current instance of AuthenticatedCIPAPISession with the headers
             set to include token, the auth_time and auth_expires time.
         """
+
         # Use the correct url if using beta dataset for testing:
         if testing_on == False:
             # Live data
@@ -77,6 +79,7 @@ class AuthenticatedCIPAPISession(requests.Session):
         else:
             # Beta test data
             cip_auth_url = (beta_testing_base_url + 'get-token/')
+
         try:
             token = (self.post(
                         cip_auth_url, data=(auth_credentials))

--- a/pyCIPAPI/interpretation_requests.py
+++ b/pyCIPAPI/interpretation_requests.py
@@ -7,9 +7,9 @@ from .auth import AuthenticatedCIPAPISession
 from .config import live_100k_data_base_url, beta_testing_base_url
 
 
-def get_interpretation_request_json(ir_id, ir_version, reports_v6=False, testing_on=False):
+def get_interpretation_request_json(ir_id, ir_version, reports_v6=False, testing_on=False, token=None):
     """Get an interpretation request as a json."""
-    s = AuthenticatedCIPAPISession(testing_on=testing_on)
+    s = AuthenticatedCIPAPISession(testing_on=testing_on, token=token)
     payload = {
         'reports_v6': reports_v6
     }
@@ -44,9 +44,10 @@ def get_interpretation_request_list(page_size=100,
                                     long_name=None,
                                     tags=None,
                                     search=None,
-                                    testing_on=False):
+                                    testing_on=False,
+                                    token=None):
     """Get a list of interpretation requests."""
-    s = AuthenticatedCIPAPISession(testing_on=testing_on)
+    s = AuthenticatedCIPAPISession(testing_on=testing_on, token=token)
     interpretation_request_list = []
 
     # Use the correct url if using beta dataset for testing (imported form config.py):

--- a/pyCIPAPI/summary_findings.py
+++ b/pyCIPAPI/summary_findings.py
@@ -82,7 +82,7 @@ def create_cr(
         return cr
 
 
-def post_cr(ir_json_v6, clinical_report, testing_on=False):
+def post_cr(ir_json_v6, clinical_report, testing_on=False, token=None):
     """
     Submit clinical report (aka summary of findings) to CIP-API.
     This uses genomics_england_tiering as the analysis partner, emulating the closing of a case through
@@ -107,11 +107,13 @@ def post_cr(ir_json_v6, clinical_report, testing_on=False):
     # Create urls for uploading exit questionnaire and summary of findings
     summary_of_findings_url = cip_api_url + cr_endpoint
     # Open Authenticated CIP-API session:
-    gel_session = AuthenticatedCIPAPISession(testing_on=testing_on)
+    gel_session = AuthenticatedCIPAPISession(testing_on=testing_on, token=token)
     # Upload Summary of findings:
     response = gel_session.post(url=summary_of_findings_url, json=clinical_report.toJsonDict())
     # Raise error if unsuccessful status code returned
     response.raise_for_status()
+
+    return response.json()
 
 
 def num_existing_reports(ir_json_v6):


### PR DESCRIPTION
- I've created an `update_token` method for the `AuthenticatedCIPAPISession()` class: An (optional) JWT token can be passed and checked for validity before creating the session. This would prevent the need for locally stored username & password (although this method is still available & the class is backwards compatible).
- I've removed the `check_auth` method as it's unused, but added the token expiry check functionality to the `update_token` method as well (will fail if <10mins left on the token)
- I've also changed the token expiry to get the expiry time from the token (`decoded_token['exp']`), rather than assuming an expiry of 30 mins.
- Minor changes to functions `get_interpretation_request_json` and `post_cr` to allow passing the token through to `AuthenticatedCIPAPISession()`.
- `post_cr` was missing a return: now returning the `response.json()` to allow confirmation of successful posting of CR.