### PR TITLE
Add setup.py resolves #9

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,0 +1,10 @@
+# JellyPy
+
+## Introduction
+.
+
+## Installation
+
+Simply run `pip install .` to install the pyCIPAPI package and its associated prequisites
+
+.

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,18 @@
+from setuptools import setup
+
+setup(name='pyCIPAPI',
+      version='0.1.0',
+      author="NHS Bioinformatics Group",
+      author_email="joowook.ahn@nhs.net",
+      description='Python library for access the GELs CPI API',
+      license="TBC",
+      url='https://github.com/NHS-NGS/JellyPy',
+      packages=['pyCIPAPI'],
+      install_requires=[
+          'docopt == 0.6.2',
+          'GelReportModels == 7.2.10',
+          'maya == 0.6.1',
+          'PyJWT == 1.7.1',
+          'requests == 2.22.0'
+      ]
+      )


### PR DESCRIPTION
I've added a setup.py to enable installing the pyCIPAPI package and it's prerequisites. I've arbitrarily chosen the latest versions as they aren't currently specified in the repo. Likewise, pyCIPAPI version is '0.1.0' as an initial version.
I've also added the start of a readme file that specifies the installation procedure, although I appreciate that there's more that should probably go in there.