### PR TITLE
Update pandas version requirement

### DIFF
--- a/pyCIPAPI/setup.py
+++ b/pyCIPAPI/setup.py
@@ -19,7 +19,6 @@ setup(
         'maya == 0.6.1',
         'PyJWT == 1.7.1',
         'requests == 2.22.0',
-        'Cython == 0.29.23',
         'pandas == 1.2.4',
         'openpyxl == 2.6.3'
     ]

--- a/pyCIPAPI/setup.py
+++ b/pyCIPAPI/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 setup(
     name='jellypy_pyCIPAPI',
-    version='0.2.3',
+    version='0.2.4',
     author="NHS Bioinformatics Group",
     author_email="joowook.ahn@nhs.net",
     description='Python client library the Genomics England CIPAPI',
@@ -19,7 +19,8 @@ setup(
         'maya == 0.6.1',
         'PyJWT == 1.7.1',
         'requests == 2.22.0',
-        'pandas == 0.25.1',
+        'Cython == 0.29.23',
+        'pandas == 1.2.4',
         'openpyxl == 2.6.3'
     ]
 )

--- a/readme.md
+++ b/readme.md
@@ -26,9 +26,11 @@ To develop a new function or feature, please take a look at the issues raised. I
 * 0.2.1 - Support legacy authentication by allowing AD to be toggled on/off in config file
 * 0.2.2 - Add sub-heading to README changelog
 * 0.2.3 - Update live 100K url. Display response on API errors. Add tests for auth api calls.
+* 0.2.4 - Fix pandas install error by using version 1.2.4
 
 ### jellypy-tierup
 
 * 0.2.0 - TierUp development release with pyCIPAPI 0.2.3
 * 0.3.0 - Use ensembl identifiers to query panel app. Implement mode of inheritance check.
 * 0.3.1 - Add version string to cli arguments. Fix GeLPanel.query docstring.
+* 0.3.2 - Use jellypy-pyCIPAPI 0.2.4

--- a/tierup/setup.py
+++ b/tierup/setup.py
@@ -5,7 +5,7 @@ README = ( pathlib.Path(__file__).parent / 'pypi_readme.md').read_text()
 
 setup(
     name='jellypy_tierup',
-    version='0.3.1',
+    version='0.3.2',
     author="NHS Bioinformatics Group",
     author_email="nana.mensah1@nhs.net",
     description='Reanalyse Tier 3 variants',
@@ -19,7 +19,7 @@ setup(
     install_requires=[
         'click==7.0',
         'jsonschema==3.2.0',
-        'jellypy-pyCIPAPI==0.2.3'
+        'jellypy-pyCIPAPI==0.2.4'
     ],
     entry_points = {
         'console_scripts': 'tierup=jellypy.tierup.interface:cli'


### PR DESCRIPTION
Updating to a release version of pandas resolves #34 
```
https://github.com/NMNS93/JellyPy.git
pip install ./JellyPy/pyCIPAPI
# Installs succesfully
```

The pandas functions used in pyCIPAPI are in the release as expected. They're used here for reference: [pd.DataFrame, pd.DataFrame.loc and pd.DataFrame.to_excel](https://github.com/NHS-NGS/JellyPy/blob/e221b36e7b8e5fb25c2041993b762cd49368cc18/scripts/cancer_cases_with_pharma_results.py#L79).

Plan to update pypi after merge.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nhs-ngs/jellypy/35)
<!-- Reviewable:end -->
